### PR TITLE
Inflated3dSVM

### DIFF
--- a/model_types/inflated_3d/requirements.txt
+++ b/model_types/inflated_3d/requirements.txt
@@ -1,0 +1,13 @@
+absl-py
+tensorflow
+tensorflow-hub
+opencv-python
+numpy
+imageio
+ipython
+matplotlib
+pillow
+pandas
+tqdm
+ipywidgets
+scikit-learn


### PR DESCRIPTION
Needs like 32 GB of ram to run.

You can also set `max_workers=1`, but it'll take a couple minutes longer to run. Thanks [Amdahl's Law](https://en.wikipedia.org/wiki/Amdahl's_law).